### PR TITLE
Update Slack channel name

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -55,7 +55,7 @@
       </p>
       <p>
         The best way to get help is via the <a href="https://ember-community-slackin.herokuapp.com/">Ember Community Slack</a>.
-        Once you've signed up, join the <code>#fastboot</code> channel.
+        Once you've signed up, join the <code>#-fastboot</code> channel.
       </p>
     </section>
 


### PR DESCRIPTION
This updates the Slack channel on the homepage from `#fastboot` to `#-fastboot`
