### PR TITLE
added $ to sh commands code blocks

### DIFF
--- a/app/styles/components/command-prompt.css
+++ b/app/styles/components/command-prompt.css
@@ -10,7 +10,7 @@ pre {
   white-space: pre;
 }
 
-.command-prompt-body:before {
+.command-prompt-body:before, .language-sh:before {
   color: #C6D1DA;
   content: '$ ';
 }


### PR DESCRIPTION
Markdown doesn't add the `.command-prompt` class, but it does add the language parse class, so added this to match the command-prompt style
