### PR TITLE
Add ember-cookies to user guide

### DIFF
--- a/markdown/docs/user-guide.md
+++ b/markdown/docs/user-guide.md
@@ -290,6 +290,34 @@ export default Route.extend({
 });
 ```
 
+In order to access cookies in a way that works both in the browser as well as
+in the FastBoot server, use
+[ember-cookies](https://github.com/simplabs/ember-cookies) and the `cookies`
+service it exposes:
+
+```js
+import Route from 'ember-route';
+import fetch from 'ember-network/fetch';
+import injectService from 'ember-service/inject';
+
+export default Route.extend({
+  fastboot: injectService(),
+  cookies: injectService(),
+
+  model(params) {
+    let authToken = this.get('cookies').read('auth');
+    let options = {
+      headers: {
+        'X-Auth-Token': authToken
+      }
+    };
+
+    return fetch(`http://api.example.com/users/${params.user_id}`, options)
+      .then(r => r.json());
+  }
+});
+```
+
 ### Check the Current Host
 
 You can access the hostname of the current FastBoot server via the


### PR DESCRIPTION
This adds [ember-cookies](https://github.com/simplabs/ember-cookies) to the "Access Cookies" section of the User Guide. I assume that in most cases people would not want to use the `cookies` property of the `fastboot` service directly as that would not work in the browser. Instead, ember-cookies exposes a service that uses `document.cookie` when executing in the browser and the `fastboot` service's `cookie` property when executing in the Fastboot server.
