### PR TITLE
Docs improvements

### DIFF
--- a/markdown/docs/user-guide.md
+++ b/markdown/docs/user-guide.md
@@ -63,7 +63,7 @@ ember build --environment production
 Deploy][ember-cli-deploy].** There are a number of FastBoot-compatible
 deploy plugins, with more being authored every day.
 
-[ember-cli-deploy]: http://ember-cli.com/ember-cli-deploy/
+[ember-cli-deploy]: http://ember-cli-deploy.github.io/ember-cli-deploy/
 
 Manual deployment is slow and error-prone, and even if you have a custom
 deployment process, writing an Ember CLI Deploy plugin is

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-fastboot-server": "hone/ember-fastboot-server#static-gzip",
+    "ember-fastboot-server": "0.7.2",
     "ember-fr-markdown-file": "0.0.0",
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.6.1",


### PR DESCRIPTION
This PR fixes a broken link to ember-cli-deploy and bump server version in order to make it property run in Windows.

Additional feedback : 
- Internal link to Architecture section is broken. This seems to be linked to the fact that remarkable does not add ids to headings (see jonschlinkert/remarkable/issues/122). This could be fixed by moving the architecture part. 
- The internal link to the deploy page is not really visible IMO, I did not seen him in a first read.

Anyway, thanks for this great work.
