### PR TITLE
update to ember-cli-fastboot 1.0.0-beta.4

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node server.js

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-deploy": "0.6.1",
     "ember-cli-deploy-build": "0.1.1",
     "ember-cli-deploy-gzip": "0.2.3",
-    "ember-cli-fastboot": "0.6.2",
+    "ember-cli-fastboot": "^1.0.0-beta.4",
     "ember-cli-head": "0.0.5",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -43,7 +43,6 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-fastboot-server": "0.7.2",
     "ember-fr-markdown-file": "0.0.0",
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.6.1",
@@ -54,5 +53,11 @@
     "postcss-custom-media": "^5.0.1",
     "postcss-custom-properties": "^5.0.0",
     "postcss-import": "^8.0.2"
+  },
+  "dependencies": {
+    "express": "^4.13.4",
+    "express-cluster": "0.0.4",
+    "express-serve-static-gzip": "hone/express-serve-static-gzip",
+    "fastboot-express-middleware": "^1.0.0-beta.7"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const fs = require('fs');
+const express = require('express');
+const cluster = require('express-cluster');
+const fastbootMiddleware = require('fastboot-express-middleware');
+const parseArgs = require('minimist');
+const staticGzip = require('express-serve-static-gzip');
+
+var assetPath = 'tmp/deploy-dist'
+var port = process.env.PORT || 3000;
+
+console.log('Booting Ember app...');
+
+try {
+  fs.accessSync(assetPath, fs.F_OK);
+} catch (e) {
+  console.error(`The asset path ${assetPath} does not exist.`);
+  process.exit(1);
+}
+
+
+// FastFail™: this is not mandatory; the first call to visit would
+// also boot the app anyway. This is just to provide useful feedback
+// instead of booting a server that keeps serving 500.
+//
+// Note that Application#buildApp is still a private API atm, so it might
+// go through more churn in the near term.
+console.log('Ember app booted successfully.');
+cluster(function() {
+  var app = express();
+
+  var fastboot = fastbootMiddleware(assetPath);
+
+  if (assetPath) {
+    app.get('/', fastboot);
+    app.use(staticGzip(assetPath)),
+    app.use(express.static(assetPath));
+  }
+
+  app.get('/*', fastboot);
+
+  var listener = app.listen(port, function() {
+    var host = listener.address().address;
+    var port = listener.address().port;
+    var family = listener.address().family;
+
+    if (family === 'IPv6') { host = '[' + host + ']'; }
+
+    console.log('Ember FastBoot running at http://' + host + ":" + port);
+  });
+}, { verbose: true });


### PR DESCRIPTION
remove ember-fastboot-server and replace it with our own handrolled
express server with the same gzip asset logic
