### PR TITLE
Automate SSL Renewal

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "express": "^4.13.4",
     "express-cluster": "0.0.4",
+    "express-sabayon": "hone/express-sabayon",
     "express-serve-static-gzip": "hone/express-serve-static-gzip",
     "fastboot-express-middleware": "^1.0.0-beta.7"
   }

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const cluster = require('express-cluster');
 const fastbootMiddleware = require('fastboot-express-middleware');
 const parseArgs = require('minimist');
 const staticGzip = require('express-serve-static-gzip');
+const sabayon = require('express-sabayon');
 
 var assetPath = 'tmp/deploy-dist'
 var port = process.env.PORT || 3000;
@@ -38,6 +39,7 @@ cluster(function() {
     app.use(express.static(assetPath));
   }
 
+  app.get(sabayon.path, sabayon.middleware());
   app.get('/*', fastboot);
 
   var listener = app.listen(port, function() {


### PR DESCRIPTION
Setup letsencrypt manually for emberconf, but now that it's expired I've taken the time to automate it to renew every 2 months. There's an express route that now handles the ACME challenges via env vars on Heroku.
