### PR TITLE
Correct the required nodejs version to match that of Fastboot

### DIFF
--- a/app/components/main-hero/template.hbs
+++ b/app/components/main-hero/template.hbs
@@ -13,7 +13,7 @@
 
     <div class="main-hero-requirements mt1">
       Ember.js 2.3+ required (Ember.js 2.4+ recommended)<br>
-      Node.js 0.12+
+      Node.js 4.0+
     </div>
   </div>
 


### PR DESCRIPTION
Updates the required Node.js version stated on the homepage to match that of [Fastboot](https://github.com/ember-fastboot/fastboot). 

See https://github.com/ember-fastboot/ember-cli-fastboot/issues/193
