### PR TITLE
Add ember-cli-deploy-fastboot-api-lambda to the deployment section

### DIFF
--- a/markdown/docs/deploying.md
+++ b/markdown/docs/deploying.md
@@ -35,8 +35,9 @@ Lambda is not recommended for serving directly to users, due to
 unpredictable response times, but is a perfect fit for pre-rendering or
 serving to search crawlers.
 
-For more about deploying FastBoot to Lambda, see [Bustle Labs'
-Lambda ember-cli-deploy plugin](https://github.com/bustlelabs/ember-cli-deploy-fastboot-lambda).
+For more about deploying FastBoot to Lambda, see either [Bustle Labs'
+Lambda ember-cli-deploy plugin](https://github.com/bustlelabs/ember-cli-deploy-fastboot-lambda). Alternatively, see [ember-cli-deploy-fastboot-api-lambda](https://github.com/wytlytningNZ/ember-cli-deploy-fastboot-api-lambda) for an end-to-end lambda/api gateway hosting solution that serves both fastboot pages and static assets.
+
 
 ## Custom Server
 

--- a/markdown/docs/deploying.md
+++ b/markdown/docs/deploying.md
@@ -36,7 +36,7 @@ unpredictable response times, but is a perfect fit for pre-rendering or
 serving to search crawlers.
 
 For more about deploying FastBoot to Lambda, see either [Bustle Labs'
-Lambda ember-cli-deploy plugin](https://github.com/bustlelabs/ember-cli-deploy-fastboot-lambda). Alternatively, see [ember-cli-deploy-fastboot-api-lambda](https://github.com/wytlytningNZ/ember-cli-deploy-fastboot-api-lambda) for an end-to-end lambda/api gateway hosting solution that serves both fastboot pages and static assets.
+Lambda ember-cli-deploy plugin](https://github.com/bustlelabs/ember-cli-deploy-fastboot-lambda). Alternatively, see [ember-cli-deploy-fastboot-api-lambda](https://github.com/wytlytningNZ/ember-cli-deploy-fastboot-api-lambda) for an end-to-end Lambda/API Gateway hosting solution that serves both Fastboot pages and static assets.
 
 
 ## Custom Server


### PR DESCRIPTION
I have created an ember-cli-deploy addon that allows you to serve ember fastboot applications entirely from within api gateway / lambda. This includes both fastboot outputs, but also any static assets bundled with the dist.
It has been quite well received, and was hoping it could find a place on the offical site. Thoughts?