### PR TITLE
Doc updates to prepare for FastBoot 1.0

### DIFF
--- a/markdown/docs/deploying.md
+++ b/markdown/docs/deploying.md
@@ -44,8 +44,6 @@ Lambda ember-cli-deploy plugin](https://github.com/bustlelabs/ember-cli-deploy-f
 
 ## Custom Server
 
-
-
 If one of the out-of-the-box deployment strategies doesn't work for you,
 you can adapt [the standalone FastBoot
 server](https://github.com/ember-fastboot/ember-fastboot-server) to your

--- a/markdown/docs/user-guide.md
+++ b/markdown/docs/user-guide.md
@@ -403,7 +403,7 @@ export default Ember.Route.extend({
 JavaScript running in the browser relies on the `XMLHttpRequest` interface to retrieve resources, while Node offers the `http` module.
 What do we do if we want to write a single app that can fetch data from our API server when running in both environments?
 
-One option is to use the [ember-network] addon, which provides an implementation of [Fetch API][fetch-api] standard that works seamlessly in both environments.
+One option is to use the [ember-fetch](https://github.com/stefanpenner/ember-fetch) addon, which provides an implementation of [Fetch API][fetch-api] standard that works seamlessly in both environments.
 
 To use `ember-fetch`, install it as you would any addon:
 
@@ -414,7 +414,7 @@ ember install ember-fetch
 Once installed, you can import it using the JavaScript module syntax, wherever you need to make a network request:
 
 ```javascript
-import fetch from 'ember-fetch/fetch';
+import fetch from 'ember-fetch/ajax';
 ```
 
 The `fetch()` method returns a promise and is very similar to jQuery's `getJSON()` method that you are likely already using.
@@ -730,7 +730,7 @@ You can upload it to a static hosting service like S3 or Firebase, where browser
 FastBoot is a little different because, instead of being purely static, it renders HTML on the server and therefore needs more than just static hosting.
 We need to build additional assets that's designed to work in Node rather than the browser.
 
-When you run `ember build`, your FastBooted app will produce `app.js` and `vendor.js` in `dist/assets` that are used in the browser and will produce an additive asset containing FastBoot overrides for your app in `app-fastboot.js` in `dist/assets`.
+When you run `ember build`, your FastBooted app will produce `app.js` and `vendor.js` in `dist/assets` that are used in the browser and Node and will produce an additive asset containing FastBoot overrides for your app in `app-fastboot.js` in `dist/assets`.
 The artifacts in `dist/assets` are client-side copies of your application that will be sent to all browsers that request your application.
 The artifacts for your FastBoot server are defined by a `manifest` key entry in `dist/package.json` which
 will minimally contain `vendor.js`, `app.js` and `app-fastboot.js`.

--- a/markdown/docs/user-guide.md
+++ b/markdown/docs/user-guide.md
@@ -34,42 +34,25 @@ This will install the `ember-cli-fastboot` addon via npm and save it to your app
 You can start a FastBoot server on your development machine by running:
 
 ```sh
-ember fastboot
+ember serve
 ```
 
-This starts a FastBoot server listening on port 3000\.
+This starts a FastBoot server listening on port 4200\.
 You can verify it's working by curling from `localhost`:
 
 ```sh
-curl http://localhost:3000
+curl 'http://localhost:4200/' -H 'Accept: text/html'
 ```
 
 You should see the content of your application's index template rendered in the output, instead of the empty HTML most client-side rendered apps show.
 
 To stop the server, press `Ctrl-C` on your keyboard to kill the process.
 
-Note that, at the moment, the server does not automatically restart when you make changes.
-If you make changes to your application, you'll need to kill the server and restart it.
-
-You can run the development server on a different port by passing the `--port` argument:
+You can run the development server on a different port by passing the `--port` argument or use any of `ember-cli` options:
 
 ```sh
-ember fastboot --port 4567
+ember serve --port 4567
 ```
-
-*Note*: `ember fastboot` command is soon going to be deprecated.
-
-## Testing Locally using `ember serve`
-
-If your app is running ember-cli 2.12.0-beta.1 and above, you can now serve your FastBoot rendered content with `ember serve` as well. Moreover, all options of `ember serve` will work with FastBoot (example `--proxy`, `--port`, `--live-reload` etc). The Node server will automatically restart when you make changes.
-
-In order to serve the CSS, JavaScript, images in addition to rendering the server side content, just run:
-
-```sh
-ember serve
-```
-
-View the FastBoot-rendered by visiting [localhost:4200](http://localhost:42000/). You can alternatively also use the following curl command: `curl 'http://localhost:4200/' -H 'Accept: text/html'`.
 
 ### Disabling FastBoot
 
@@ -94,7 +77,7 @@ As with a standard Ember build for the browser, compiled assets by default go in
 FastBoot adds two additions:
 
 1. `dist/package.json`, which contains metadata about your app for consumption by the FastBoot server.
-2. `dist/fastboot/`, which contains your app's compiled JavaScript that is evaluated and run by the FastBoot server.
+2. `dist/assets/`, which contains your app's compiled JavaScript that is evaluated and run by the FastBoot server (`vendor.js`, `app.js`, `app-fastboot.js`).
 
 For more information, see the [Architecture](#architecture) section.
 
@@ -415,23 +398,23 @@ export default Ember.Route.extend({
 
 ## Useful Ember Addons for FastBoot
 
-### ember-network: Fetch Resources Over HTTP (AJAX)
+### ember-fetch: Fetch Resources Over HTTP (AJAX)
 
 JavaScript running in the browser relies on the `XMLHttpRequest` interface to retrieve resources, while Node offers the `http` module.
 What do we do if we want to write a single app that can fetch data from our API server when running in both environments?
 
 One option is to use the [ember-network] addon, which provides an implementation of [Fetch API][fetch-api] standard that works seamlessly in both environments.
 
-To use `ember-network`, install it as you would any addon:
+To use `ember-fetch`, install it as you would any addon:
 
 ```sh
-ember install ember-network
+ember install ember-fetch
 ```
 
 Once installed, you can import it using the JavaScript module syntax, wherever you need to make a network request:
 
 ```javascript
-import fetch from 'ember-network/fetch';
+import fetch from 'ember-fetch/fetch';
 ```
 
 The `fetch()` method returns a promise and is very similar to jQuery's `getJSON()` method that you are likely already using.
@@ -439,7 +422,7 @@ For example, here's an Ember route that uses `fetch()` to access the GitHub JSON
 
 ```javascript
 import Route from 'ember-route';
-import fetch from 'ember-network/fetch';
+import fetch from 'ember-fetch/fetch';
 
 export default Route.extend({
   model() {
@@ -451,7 +434,7 @@ export default Route.extend({
 });
 ```
 
-For more information, see [ember-network] and the [Fetch documentation on MDN][fetch-api].
+For more information, see [ember-fetch](https://github.com/stefanpenner/ember-fetch) and the [Fetch documentation on MDN][fetch-api].
 
 ### ember-cli-document-title: Specify the Page Title
 
@@ -472,7 +455,7 @@ export default Ember.Route.extend({
 });
 ```
 
-See [ember-cli-document-title] for more information.
+See [ember-cli-document-title](https://github.com/kimroen/ember-cli-document-title) for more information.
 
 ### ember-cli-head: Enable Open Graph, Twitter Cards and Other `<head>` Tags
 
@@ -514,7 +497,7 @@ export default Ember.Route.extend({
 });
 ```
 
-For more information, see [ember-cli-head].
+For more information, see [ember-cli-head](https://github.com/ronco/ember-cli-head).
 
 ## Tips and Tricks
 
@@ -650,9 +633,9 @@ Any code in these hooks will be run inside of FastBoot and should be free of ref
 FastBoot relies on [`Ember.ApplicationInstance`](http://emberjs.com/api/classes/Ember.ApplicationInstance.html) to execute your Ember application on the server.
 jQuery is [disabled](https://github.com/emberjs/ember.js/blob/v2.7.0/packages/ember-application/lib/system/application-instance.js#L370) by default for these instances because most of jQuery depends on having full DOM access.
 
-### Use `ember-network` for XHR requests
+### Use `ember-fetch` for XHR requests
 
-If you are depending on jQuery for XHR requests, use [ember-network](https://github.com/tomdale/ember-network) and replace your `$.ajax` calls with `fetch` calls.
+If you are depending on jQuery for XHR requests, use [ember-fetch](https://github.com/stefanpenner/ember-fetch) and replace your `$.ajax` calls with `fetch` calls.
 
 ## Troubleshooting in Node
 
@@ -663,7 +646,7 @@ Because your app is now running in Node, not the browser, you will need a new se
 Enable verbose logging by running the FastBoot server with the following environment variables set:
 
 ```sh
-DEBUG=ember-cli-fastboot:* ember fastboot
+DEBUG=ember-cli-fastboot:* ember serve
 ```
 
 Pull requests for adding or improving logging facilities are very welcome.
@@ -688,14 +671,14 @@ node-inspector --no-preload
 
 Once the debug server is running, you'll want to start up the FastBoot server with Node in debug mode.
 One thing about debug mode: it makes everything much slower.
-Since the `ember fastboot` command does a full build when launched, this becomes agonizingly slow in debug mode.
+Since the `ember serve` command does a full build when launched, this becomes agonizingly slow in debug mode.
 
 ### Speeding up Server-side Debugging
 
 Avoid the slowness by manually running the build in normal mode, then run FastBoot in debug mode without doing a build:
 
 ```sh
-ember build && node --debug-brk ./node_modules/.bin/ember fastboot --no-build
+ember build && node --debug-brk ./node_modules/.bin/ember serve
 ```
 
 This does a full rebuild and then starts the FastBoot server in debug mode.
@@ -745,13 +728,14 @@ That directory contains everything you need to make your application work in the
 You can upload it to a static hosting service like S3 or Firebase, where browsers can download and run the JavaScript on the user's device.
 
 FastBoot is a little different because, instead of being purely static, it renders HTML on the server and therefore needs more than just static hosting.
-We need to produce a build of the Ember app that's designed to work in Node rather than the browser.
+We need to build additional assets that's designed to work in Node rather than the browser.
 
-When you run `ember build`, your FastBooted app will produce different artifact sets in `dist/` and `dist/fastboot`.
-The artifacts in `dist` are client-side copies of your application that will be sent to all browsers that request your application.
-The artifacts in `dist/fastboot` are used by the FastBoot Server to SSR your page.
+When you run `ember build`, your FastBooted app will produce `app.js` and `vendor.js` in `dist/assets` that are used in the browser and will produce an additive asset containing FastBoot overrides for your app in `app-fastboot.js` in `dist/assets`.
+The artifacts in `dist/assets` are client-side copies of your application that will be sent to all browsers that request your application.
+The artifacts for your FastBoot server are defined by a `manifest` key entry in `dist/package.json` which
+will minimally contain `vendor.js`, `app.js` and `app-fastboot.js`.
 
-You can test that the process is working (and that your app is FastBoot-compatible) by running `ember fastboot`, which builds your app then starts up a local server.
+You can test that the process is working (and that your app is FastBoot-compatible) by running `ember serve`, which builds your app then starts up a local server and renders your app on server side.
 
 Once you've confirmed everything looks good, it's ready to hand off to the FastBoot server running in the production environment.
 The good news is that this process is usually handled for you by a deployment plugin for `ember-cli-deploy`; see [Deploying](/docs/deploying) for more information about different deployment strategies.
@@ -764,8 +748,8 @@ The server offers an [Express middleware][express] that can be integrated into a
 
 ```javascript
 var server = new FastBootServer({
-  appFile: appFile,
-  vendorFile: vendorFile,
+  appFiles: [appFile, appFile-fastboot],
+  vendorFiles: [vendorFile],
   htmlFile: htmlFile,
   ui: ui
 });

--- a/markdown/docs/user-guide.md
+++ b/markdown/docs/user-guide.md
@@ -422,13 +422,13 @@ For example, here's an Ember route that uses `fetch()` to access the GitHub JSON
 
 ```javascript
 import Route from 'ember-route';
-import fetch from 'ember-fetch/fetch';
+import fetch from 'ember-fetch/ajax';
 
 export default Route.extend({
   model() {
     return fetch('https://api.github.com/users/tomdale/events')
       .then(function(response) {
-        return response.json();
+        return response;
       });
   }
 });
@@ -748,7 +748,7 @@ The server offers an [Express middleware][express] that can be integrated into a
 
 ```javascript
 var server = new FastBootServer({
-  appFiles: [appFile, appFile-fastboot],
+  appFiles: [appFile, appFastBootFile],
   vendorFiles: [vendorFile],
   htmlFile: htmlFile,
   ui: ui

--- a/markdown/intro.md
+++ b/markdown/intro.md
@@ -32,4 +32,4 @@ The best way to get help is via the [Ember Community Slack](https://ember-commun
 
 FastBoot is currently pre-1.0 software and under active development. You can track progress to FastBoot 1.0 by visiting the [Road to 1.0](https://github.com/ember-fastboot/ember-cli-fastboot/issues/396) GitHub issue.
 
-As addon authors or if you wish to contribute please help us in shipping in FastBoot 1.0 with helping fix addons listed in this [issue](https://github.com/ember-fastboot/ember-cli-fastboot/issues/387).
+If you wish to contribute and help in shipping FastBoot 1.0, please help us in with fixing addons listed in this [issue](https://github.com/ember-fastboot/ember-cli-fastboot/issues/387).

--- a/markdown/intro.md
+++ b/markdown/intro.md
@@ -17,7 +17,7 @@ For more information, see [the User Guide](/docs/user-guide)
 To start the FastBoot server during development:
 
 ```sh
-ember fastboot
+ember serve
 ```
 
 For more information, see the [Quickstart](/quickstart).
@@ -30,4 +30,6 @@ The best way to get help is via the [Ember Community Slack](https://ember-commun
 
 ### The Road to FastBoot 1.0
 
-FastBoot is currently pre-1.0 software and under active development. You can track progress to FastBoot 1.0 by visiting the [Road to 1.0](https://github.com/tildeio/ember-cli-fastboot/issues/98) GitHub issue.
+FastBoot is currently pre-1.0 software and under active development. You can track progress to FastBoot 1.0 by visiting the [Road to 1.0](https://github.com/ember-fastboot/ember-cli-fastboot/issues/396) GitHub issue.
+
+As addon authors or if you wish to contribute please help us in shipping in FastBoot 1.0 with helping fix addons listed in this [issue](https://github.com/ember-fastboot/ember-cli-fastboot/issues/387).

--- a/markdown/quickstart.md
+++ b/markdown/quickstart.md
@@ -131,12 +131,4 @@ Now that you've got your first FastBoot app, it's time to start adding FastBoot 
 
 If your app is running ember-cli 2.12.0-beta.1 and above, you can now serve your FastBoot rendered content with `ember serve` as well.
 
-In order to serve the CSS, JavaScript, images in addition to rendering the server side content, just run:
-
-```sh
-ember serve
-```
-
-View the FastBoot-rendered by visiting [localhost:4200](http://localhost:42000/). You can alternatively also use the following curl command: `curl 'http://localhost:4200/' -H 'Accept: text/html'`.
-
 You can also turn off the server side rendering on a per request basis using `fastboot` query parameter. To disable FastBoot rendered content, visit [localhost:4200/?fastboot=false](http://localhost:4200/?fastboot=false). You can enable FastBoot rendered content again by visiting [localhost:4200/?fastboot=true](http://localhost:4200/?fastboot=true).

--- a/markdown/quickstart.md
+++ b/markdown/quickstart.md
@@ -52,13 +52,13 @@ Implement the model hook like I did below. You might want to change the username
 
 ```javascript
 import Ember from 'ember';
-import fetch from 'ember-fetch/fetch';
+import fetch from 'ember-fetch/ajax';
 
 export default Ember.Route.extend({
   model() {
     return fetch('https://api.github.com/users/tomdale')
       .then(function(response) {
-        return response.json();
+        return response;
       });
   }
 });

--- a/markdown/quickstart.md
+++ b/markdown/quickstart.md
@@ -24,10 +24,10 @@ We need to fetch data from the GitHub API, but there's a small problem: the brow
 
 Let's install a tool that will let us write the same code whether our app is running in the browser or on the server. Code that runs in both places is sometimes called _universal_ or _isomorphic_.
 
-Run the following command to install `ember-network`:
+Run the following command to install `ember-fetch`:
 
 ```sh
-ember install ember-network
+ember install ember-fetch
 ```
 
 Under the hood, the `ember install` command is just like `npm install`, but automatically saves the addon to your `package.json` file.
@@ -46,13 +46,13 @@ This will generate a new route called `index`. By convention, `index` is the nam
 
 Open the newly-created `app/routes/index.js` file in your code editor. Let's add a method called `model()` to the route that fetches information about your user from GitHub.
 
-We'll use the `fetch` polyfill exposed by the `ember-network` addon that lets us write universal fetching code for both the browser and Node.js. A _polyfill_ is a library that provides a standardized API that isn't available in all environments yet. In this case, it's polyfilling the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+We'll use the `fetch` polyfill exposed by the `ember-fetch` addon that lets us write universal fetching code for both the browser and Node.js. A _polyfill_ is a library that provides a standardized API that isn't available in all environments yet. In this case, it's polyfilling the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
 Implement the model hook like I did below. You might want to change the username in the URL from mine to yours.
 
 ```javascript
 import Ember from 'ember';
-import fetch from 'ember-network/fetch';
+import fetch from 'ember-fetch/fetch';
 
 export default Ember.Route.extend({
   model() {
@@ -102,17 +102,15 @@ Next, install FastBoot:
 ember install ember-cli-fastboot
 ```
 
-Let's turn on server-side rendering and make sure it works. Start the FastBoot server like this:
+Let's turn on server-side rendering and make sure it works. Start the FastBoot server like this if you have `ember-cli` 2.12.0 and above in your app:
 
 ```sh
-ember fastboot --serve-assets
+ember serve
 ```
 
-The `--serve-assets` option tells the FastBoot server to serve CSS, JavaScript and images in addition to just rendering the HTML.
+*Note*: `ember fastboot` command is soon going to be deprecated and removed in FastBoot 1.0. Please refrain from using it as it has live-reload and other issues
 
-*Note*: `ember fastboot` command is soon going to be deprecated.
-
-View the FastBoot-rendered content by visiting [localhost:3000/](http://localhost:3000/). Note the different port! This is port 3000 instead of port 4200 like before.
+View the FastBoot-rendered content by visiting [localhost:4200/](http://localhost:4200/). Note the same port! `ember serve` can serve render your app on server side as well. Moreover, all options of `ember serve` will work with FastBoot (example `--proxy`, `--port` etc).
 
 Everything should look just the same as before. The only difference is that, this time when you View Source, the `<body>` tag is populated with the rendered HTML content.
 
@@ -123,15 +121,15 @@ Congratulations! You've just built your first FastBoot application.
 Let's review what we've accomplished here:
 
 1. We created a new app in one command with `ember new`
-2. We used the universal library `ember-network` to request AJAX data
+2. We used the universal library `ember-fetch` to request AJAX data
 3. When rendering in Node.js, the FastBoot server requested data from GitHub _on the user's behalf_
 4. We wrote an app that has the benefits of traditional server-side rendering **and** the benefits of client-side JavaScript, in a single codebase. No hacks, just installing an addon.
 
 Now that you've got your first FastBoot app, it's time to start adding FastBoot to your existing apps. Or, learn how to deploy your new app by learning about [Deploying](/docs/deploying).
 
-### Running FastBoot with `ember serve`
+### Disabling FastBoot with `ember serve`
 
-If your app is running ember-cli 2.12.0-beta.1 and above, you can now serve your FastBoot rendered content with `ember serve` as well. Moreover, all options of `ember serve` will work with FastBoot (example `--proxy`, `--port` etc).
+If your app is running ember-cli 2.12.0-beta.1 and above, you can now serve your FastBoot rendered content with `ember serve` as well.
 
 In order to serve the CSS, JavaScript, images in addition to rendering the server side content, just run:
 


### PR DESCRIPTION
Fixes https://github.com/ember-fastboot/fastboot-website/issues/54

This PR fixes issues on the website which called to use `ember fastboot`. With FastBoot 1.0 and starting with the RC builds, `ember fastboot` will be gone. Also tweaked wording a bit to explain the new build in short.

The irony this app is using `ember fastboot --serve-assets` instead of `ember serve`. Going to bump ember version and using ember serve in a seperate PR.

cc: @stefanpenner @tomdale 