### PR TITLE
Remove fastly dependency & add immutable cache control header

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,11 +3,6 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
-  let prepend = '';
-
-  if ('FASTLY_CDN_URL' in process.env) {
-    prepend = 'https://' + process.env.FASTLY_CDN_URL + '/';
-  }
 
   const app = new EmberApp(defaults, {
     postcssOptions: {
@@ -34,9 +29,6 @@ module.exports = function(defaults) {
           }
         ]
       }
-    },
-    fingerprint: {
-      prepend: prepend
     }
   });
 

--- a/fastboot-server.js
+++ b/fastboot-server.js
@@ -36,7 +36,12 @@ cluster(function() {
   if (assetPath) {
     app.get('/', fastboot);
     app.use(staticGzip(assetPath)),
-    app.use(express.static(assetPath));
+      app.use(express.static(assetPath, {
+        setHeaders(res, path, stat) {
+          res.setHeader('Cache-Control', 'public, max-age=365000000, immutable');
+          res.removeHeader('X-Powered-By');
+        }
+      }));
   }
 
   app.get(sabayon.path, sabayon.middleware());


### PR DESCRIPTION
We're doing this as a part of migrating the heroku app from the ember-conf org to ember org. We will reintroduce fastly as a service in the near future via a different PR. This PR adds immutable cache control headers so that the assets get cached indefinitely.

//cc @locks 