### PR TITLE
Add a link to edit the current page on github

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/boron

--- a/app/components/edit-link/component.js
+++ b/app/components/edit-link/component.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: '',
+});

--- a/app/components/edit-link/template.hbs
+++ b/app/components/edit-link/template.hbs
@@ -1,0 +1,11 @@
+<a
+  class="edit-link right"
+  title="Edit on Github"
+  href="https://github.com/ember-fastboot/fastboot-website/edit/master/markdown/{{path}}.md"
+  target="_blank"
+  rel="noopener"
+>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -256 1792 1792">
+    <path d="M484.492 1270.237l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z" fill="currentColor"></path>
+  </svg>
+</a>

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,6 +4,6 @@ import markdownFiles from 'ember-fr-markdown-file/markdownFiles';
 
 export default Route.extend({
   model() {
-    return get(markdownFiles, 'intro');
-  }
+    return {markdown: get(markdownFiles, 'intro'), path: 'intro'};
+  },
 });

--- a/app/routes/page.js
+++ b/app/routes/page.js
@@ -4,6 +4,7 @@ import markdownFiles from 'ember-fr-markdown-file/markdownFiles';
 
 export default Route.extend({
   model(params) {
-    return get(markdownFiles, params.path.replace(/\//g, '.')) || null;
-  }
+    const path = params.path;
+    return {markdown: get(markdownFiles, path.replace(/\//g, '.')) || null, path};
+  },
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -8,6 +8,7 @@
 @import "components/main-hero";
 @import "components/main-hero-terminal";
 @import "components/main-nav";
+@import "components/edit-link";
 @import "components/syntax";
 
 :root {

--- a/app/styles/components/edit-link.css
+++ b/app/styles/components/edit-link.css
@@ -1,0 +1,5 @@
+.edit-link {
+  width: 20px;
+  text-decoration: none;
+  border-bottom: none;
+}

--- a/app/templates/components/main-nav.hbs
+++ b/app/templates/components/main-nav.hbs
@@ -1,4 +1,5 @@
 {{fastboot-logo}}
+{{edit-link path=path}}
 <ul class="list-reset">
   <li class="inline-block mr1">{{link-to 'Intro' 'index'}}</li>
   <li class="inline-block mr1">{{link-to 'Quickstart' 'page' 'quickstart'}}</li>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,8 +1,8 @@
 {{main-hero}}
 
 <div class="p1">
-  {{main-nav}}
+  {{main-nav path=model.path}}
   <section class="max-width-3 mx-auto">
-    {{md-text text=model html=true typographer=true linkify=true}}
+    {{md-text text=model.markdown html=true typographer=true linkify=true}}
   </section>
 </div>

--- a/app/templates/page.hbs
+++ b/app/templates/page.hbs
@@ -1,6 +1,6 @@
 <div class="p1">
-  {{main-nav}}
-  {{#liquid-bind model as |currentModel|}}
+  {{main-nav path=model.path}}
+  {{#liquid-bind model.markdown as |currentModel|}}
     <section class="max-width-3 mx-auto">
       {{#if currentModel}}
         {{md-text text=currentModel html=true typographer=true linkify=true}}


### PR DESCRIPTION
Fixes #88

I basically emulated what is done on the Ember API docs pages, including copying the SVG pencil icon from those pages (though I stopped short of providing a popover with the title).

For example, [this](https://github.com/ember-fastboot/fastboot-website/edit/master/markdown/quickstart.md) is the link from the Quickstart page.

<img width="852" alt="screen shot 2018-11-28 at 8 35 40 pm" src="https://user-images.githubusercontent.com/50039/49199593-8b4e5c80-f34d-11e8-824c-b75e113d1d7b.png">