### PR TITLE
Make sure `Useful Links` show up

### DIFF
--- a/markdown/docs/user-guide.md
+++ b/markdown/docs/user-guide.md
@@ -928,10 +928,10 @@ If you discover a security vulnerability in FastBoot, we ask that you follow Emb
 
 ## Useful Links
 
-[ember-cli-deploy]: http://ember-cli-deploy.github.io/ember-cli-deploy/
-[ember-cli-document-title]: https://github.com/kimroen/ember-cli-document-title
-[ember-cli-head]: https://github.com/ronco/ember-cli-head
-[ember-network]: https://github.com/tomdale/ember-network
-[express]: http://expressjs.com
-[fastboot-server]: https://github.com/ember-fastboot/ember-fastboot-server
-[fetch-api]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+* [ember-cli-deploy](http://ember-cli-deploy.github.io/ember-cli-deploy/)
+* [ember-cli-document-title](https://github.com/kimroen/ember-cli-document-title)
+* [ember-cli-head](https://github.com/ronco/ember-cli-head)
+* [ember-fetch](https://github.com/ember-cli/ember-fetch)
+* [express](http://expressjs.com)
+* [fastboot-server](https://github.com/ember-fastboot/ember-fastboot-server)
+* [fetch-api](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)


### PR DESCRIPTION
Add ember-fetch
Remove ember-network which has been archived

before: 
![image](https://user-images.githubusercontent.com/647691/56785997-30aa1700-67ac-11e9-91e5-1270d40c575b.png)

after: 
![image](https://user-images.githubusercontent.com/647691/56786009-3c95d900-67ac-11e9-8566-18daf063a0c3.png)
