### PR TITLE
Use ember module imports in doc code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To run the website locally:
 - `cd fastboot-website`
 - `npm install`
 - `ember serve`
-- Visit the app at <http://localhost:3000>.
+- Visit the app at <http://localhost:4200>.
 
 ### Running Tests
 

--- a/markdown/docs/addon-author-guide.md
+++ b/markdown/docs/addon-author-guide.md
@@ -96,7 +96,7 @@ our component file that's shared across all instances of the component:
 ```js
 // addon/components/resizable-component.js
 import Component from '@ember/component';
-import $ from "jquery";
+import $ from 'jquery';
 
 let componentsToNotify = [];
 $(window).on('resize', () => {
@@ -136,7 +136,7 @@ and never in Node).
 ```js
 // addon/components/resizable-component.js
 import Component from '@ember/component';
-import $ from "jquery";
+import $ from 'jquery';
 
 let componentsToNotify = [];
 let didSetupListener = false;

--- a/markdown/docs/addon-author-guide.md
+++ b/markdown/docs/addon-author-guide.md
@@ -95,7 +95,7 @@ our component file that's shared across all instances of the component:
 
 ```js
 // addon/components/resizable-component.js
-import Ember from "ember";
+import Component from '@ember/component';
 import $ from "jquery";
 
 let componentsToNotify = [];
@@ -103,7 +103,7 @@ $(window).on('resize', () => {
   componentsToNotify.forEach(c => c.windowDidResize());
 });
 
-export default Ember.Component.extend({
+export default Component.extend({
   init() {
     componentsToNotify.push(this);
   },
@@ -135,7 +135,7 @@ and never in Node).
 
 ```js
 // addon/components/resizable-component.js
-import Ember from "ember";
+import Component from '@ember/component';
 import $ from "jquery";
 
 let componentsToNotify = [];
@@ -148,7 +148,7 @@ function setupListener() {
   });
 }
 
-export default Ember.Component.extend({
+export default Component.extend({
   didInsertElement() {
     if (!didSetupListener) { setupListener(); }
     componentsToNotify.push(this);
@@ -429,17 +429,19 @@ Instead, you can write a computed property that uses the low-level
 `getOwner` functionality to lookup the `fastboot` service directly:
 
 ```js
-import Ember from "ember";
+import Service from '@ember/service';
+import { computed }  from '@ember/object';
+import { getOwner }  from '@ember/application';
 
-export default Ember.Service.extend({
+export default Service.extend({
   doSomething() {
     let fastboot = this.get('fastboot');
     if (!fastboot) { return; }
     // do something that requires FastBoot
   },
 
-  fastboot: Ember.computed(function() {
-    let owner = Ember.getOwner(this);
+  fastboot: computed(function() {
+    let owner = getOwner(this);
 
     return owner.lookup('service:fastboot');
   })


### PR DESCRIPTION
- Switches to Ember module imports in the code snippets
- Corrects the ember server port in the README
- a few single quotes