### PR TITLE
Removing outdated link to meetup and subsequent template/css files

### DIFF
--- a/app/components/main-hero/template.hbs
+++ b/app/components/main-hero/template.hbs
@@ -26,6 +26,4 @@
       User Guide
     {{/link-to}}
   </div>
-
-  {{main-hero/meetup}}
 </div>


### PR DESCRIPTION
Fixes issue #117

Deletes meetup template file and corresponding css files
Removes reference of rendering these in the main (main-hero) template and import in css 

Before: 
<img width="1440" alt="Screen Shot 2021-05-07 at 2 42 17 PM" src="https://user-images.githubusercontent.com/12375430/117511606-dd463400-af42-11eb-8271-0802af0e44dc.png">

After:
<img width="1440" alt="Screen Shot 2021-05-07 at 2 34 49 PM" src="https://user-images.githubusercontent.com/12375430/117511632-e8995f80-af42-11eb-9db6-f2cbd29cbe14.png">
